### PR TITLE
Fixed a bug in IntegratorsSERK

### DIFF
--- a/src/integrators/rk/integrators_serk.jl
+++ b/src/integrators/rk/integrators_serk.jl
@@ -75,7 +75,7 @@ struct IntegratorSERK{DT,TT,FT} <: StochasticIntegrator{DT,TT}
         S = tableau.s
 
         # create solution vectors
-        q = create_solution_vector_double_double(DT, D, NS, NI)
+        q = create_solution_vector(DT, D, NS, NI)
 
         new(equation, tableau, Δt, zeros(DT,M), zeros(DT,M),
             q, zeros(DT,D,S), zeros(DT,D,M,S),


### PR DESCRIPTION
Replaced create_solution_vector_double_double with create_solution_vector. This was overlooked in the recent merging of the branches.