### PR TITLE
Convert Int to BlasInt for LAPACK

### DIFF
--- a/src/Tableaus.jl
+++ b/src/Tableaus.jl
@@ -76,6 +76,7 @@ module Tableaus
 
     export getTableauPlaten, getTableauBurrageR2, getTableauBurrageCL
     export getTableauBurrageE1, getTableauBurrageG5, getTableauStochasticHeun
+    export getTableauStochasticEuler
 
     include("tableaus/tableaus_werk.jl")
 

--- a/src/solvers/linear/lu_solver_lapack.jl
+++ b/src/solvers/linear/lu_solver_lapack.jl
@@ -53,7 +53,7 @@ for (getrf, getrs, elty) in
 
         function solve!(lu::LUSolverLAPACK{$elty})
             trans = UInt8('N')
-            nrhs = 1
+            nrhs = BlasInt(1)
             ccall((@blasfunc($getrs), liblapack), Nothing,
                   (Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),

--- a/src/solvers/nonlinear/nonlinear_solvers.jl
+++ b/src/solvers/nonlinear/nonlinear_solvers.jl
@@ -125,7 +125,7 @@ function getLinearSolver(T, n)
 
     if linear_solver == nothing || linear_solver == :lapack
     # if linear_solver == :lapack
-        linear_solver = LUSolverLAPACK{T}(n)
+        linear_solver = LUSolverLAPACK{T}(BlasInt(n))
     elseif linear_solver == :julia
         linear_solver = LUSolver{T}(n)
     # elseif linear_solver == nothing

--- a/src/tableaus/tableaus_serk.jl
+++ b/src/tableaus/tableaus_serk.jl
@@ -1,3 +1,13 @@
+"Tableau for the explicit 1-stage stochastic Euler method"
+function getTableauStochasticEuler()
+  a = zeros(Float64, 1, 1)
+  b = [1.0]
+  c = [0.0]
+
+  TableauSERK(:Stochastic_Euler_explicit_method, 1, a, b, c, 1, a, b, c)
+end
+
+
 "Tableau for the explicit 2-stage stochastic Heun method"
 function getTableauStochasticHeun()
 


### PR DESCRIPTION
On a custom built Julia 1.1 in ArchLinux, LUSolverLAPACK would throw an error, since BlasInt=Int32, but standard Int in Julia is Int64. These small changes do the according conversion. Alternatively one could add a method LUSolverLAPACK(n::Int) and convert inside (with the danger that one might in theory cause an overflow)